### PR TITLE
feat(github): add markdown-studio to featured projects

### DIFF
--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -227,9 +227,10 @@ export async function fetchFeaturedProjects() {
 
     // Filter for featured repositories (customize this list)
     const featuredRepoNames = [
-      "mcp-git-commit-generator",
+      "markdown-studio",
       "css-modules-types-generator",
       "express-greeklish",
+      "mcp-git-commit-generator",
     ];
 
     const featuredRepos = featuredRepoNames


### PR DESCRIPTION
## Summary

Adds the `markdown-studio` project to the featured projects list displayed on the homepage portfolio section.

## Changes

- Include `markdown-studio` repository in the `featuredRepoNames` array in `src/utils/github.ts`

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Code follows the project style guidelines
- [x] The change is self-contained and focused
